### PR TITLE
SSR RSC Tutorial: Section 5

### DIFF
--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -186,3 +186,4 @@ Thank you so much for joining me on this guided tutorial.
 - RSC no framework: https://timtech.blog/posts/react-server-components-rsc-no-framework/
 - RSC overview https://www.joshwcomeau.com/react/server-components/
 - Kent-c-dodds RSC mvp: https://www.youtube.com/watch?v=4S5m5Jhneds
+- Data Fetching with RSC: https://www.youtube.com/watch?v=TQQPAU21ZUw&t=1048s

--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -141,11 +141,19 @@ Notice that in the `im-streaming-html` page, I don't actually do any clientside 
 
 # SECTION 5: Serverside Rendering React with Suspense, Streaming, WITH Clientside Hydration
 
-In the previous section we saw Suspense and HTML streaming in action. However, I did not hydrate the clientside application. Let's do that now. I created a new endpoint `/im-streaming-html-with-hydration` that adds a param to `bootstrapScripts`. The script I gave it is a `hydrateRoot()` call, like we have done in previous sections.
+In the previous section we saw Suspense and HTML streaming in action. However, I did not hydrate the clientside application. Let's do that now. I created a new endpoint `/im-streaming-html-with-hydration-broken` that adds a param to `bootstrapScripts`. The script I gave it is a `hydrateRoot()` call, like we have done in previous sections.
 
 Open the page, and check the console logs. Notice that fetching now happens in an infinite loop, and we also get a warning from React:
 
 `A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.`
+
+The problem is that once we hydrate our application, it creates a new `fetchData` promise on the clientside. Once that `fetchData` promise resolves on the clientside it triggers a rerender that creates a new `fetchData` promise. Thus we get stuck in an infinite loop. Notice the React warning here:
+
+`except via a Suspense-compatible library or framework.`
+
+Unfortunately this is a touchy subject, and React has been criticized for potentially keeping this implementation "secret" to discourage us from integrating with Suspense on our own. Instead, we should rely on a meta-framework like NextJS or Remix. This has been a controversy / drama. In this tutorial, I will fix this error with a very straightforward logic: using an if-statement, if I am on the clientside, then return a Promise that never resolves; Eventually the streaming HTML will come in. This is absolutely not a production-ready solution, but I wanted to be transparent about this whole caveat.
+
+You can 
 
 # SECTION 6: React Server Components
 

--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -137,11 +137,15 @@ Watch as new HTML comes in every second. This is exactly what's happening in the
 
 So now you see how `Suspense` and `Streaming` is an optimization.
 
-Notice that in the `im-streaming-html` page, I don't actually do any clientside hydration. Let's do that in the next section, because I want to also explain a new concept: "Selective Hydration".
+Notice that in the `im-streaming-html` page, I don't actually do any clientside hydration. Let's do that in the next section
 
 # SECTION 5: Serverside Rendering React with Suspense, Streaming, WITH Clientside Hydration
 
-This section introduces the concept of "Selective Hydration".
+In the previous section we saw Suspense and HTML streaming in action. However, I did not hydrate the clientside application. Let's do that now. I created a new endpoint `/im-streaming-html-with-hydration` that adds a param to `bootstrapScripts`. The script I gave it is a `hydrateRoot()` call, like we have done in previous sections.
+
+Open the page, and check the console logs. Notice that fetching now happens in an infinite loop, and we also get a warning from React:
+
+`A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.`
 
 # SECTION 6: React Server Components
 
@@ -155,7 +159,7 @@ Alas, we have arrived.
 
 # SECTION 8: Conclusion
 
-Thank you so much for joining me on this guided tutorial. 
+Thank you so much for joining me on this guided tutorial.
 
 # Additional Resources
 - Implement ssr: https://www.youtube.com/watch?v=NwyQONeqRXA

--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -102,18 +102,18 @@ Please look at `im-streaming-html/NoStreaming.jsx`. You will see a "Comment Sect
 
 Now look at the server code for `/no-streaming-html` (Line #93). Everything here should look familiar, I am using `renderToString` and hydrating on the clientside. Go ahead and visit http://localhost:3000/no-streaming-html.
 
-Everything looks good right? Each Comment component is "fetching" data and then rerenders when the data loads in. Here's the bottleneck:
+Everything looks good right? Each Comment component is "fetching" data and then rerenders when the data loads in. There is a bottleneck:
 
-**None of the data fetching can start until hydration is complete!** Remember we are using `useEffect`, and that can only be used with React javascript, after hydration. So now we have a waterfall. These steps must happen in order.
+None of the data fetching can start until hydration is complete. Remember we are using `useEffect`, and that can only be used with React javascript, after hydration. So now we have a waterfall:
 
 1. Render HTML on server and send to client
 2. Client receives HTML, downloads Javascript, and hydrates application
 3. Comment components start fetching (look at your browser console logs)
 
-Now, allow me to introduce Suspense and Streaming.
+This is considered a waterfall because these steps must happen in order, one after the other. Let us see how Suspense and Streaming can mitigate this bottleneck.
 
 - Streams are a [Web API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). The main idea is that streams send data in chunks as the data becomes ready, and a receiver can process those chunks immediately as they come in.
-- Suspense is a React API. Suspense allows you to "magically" take advantage of streaming. Well, hopefully less magical after this section.
+- Suspense is a React API that renders a fallback component while its child component is resolving a promise. Using this API, we can render the fallback UI immediately and then stream the updated UI once it is ready.
 
 Please look at `im-streaming-html/Streaming.jsx`. You can see I've implemented the same application, but this time using `<Suspense>`. On the server (Line #111), instead of `renderToString` I use a new API called `renderToPipeableStream`. Now I can stream chunks of data to the client as they become available. You will see this in action.
 

--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -137,10 +137,6 @@ Watch as new HTML comes in every second. This is exactly what's happening in the
 
 So now you see how `Suspense` and `Streaming` is an optimization.
 
-> BONUS: If you're curious, open your inspector and see the HTML that got sent. See if you can figure out the "magic" that React is doing to replace the HTML elements as they come in.
-
-I must confess one detail.
-
 Notice that in the `im-streaming-html` page, I don't actually do any clientside hydration. Let's do that in the next section, because I want to also explain a new concept: "Selective Hydration".
 
 # SECTION 5: Serverside Rendering React with Suspense, Streaming, WITH Clientside Hydration

--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -168,3 +168,5 @@ Thank you so much for joining me on this guided tutorial.
 - RSC from scratch: https://www.youtube.com/watch?v=MaebEqhZR84&pp=ygUocmVhY3Qgc2VydmVyIGNvbXBvbmVudHMgZnJvbSBzY3JhdGNoIGJlbg%3D%3D
 - New Suspense SSR Architecture in React 18: https://github.com/reactwg/react-18/discussions/37
 - RSC no framework: https://timtech.blog/posts/react-server-components-rsc-no-framework/
+- RSC overview https://www.joshwcomeau.com/react/server-components/
+- Kent-c-dodds RSC mvp: https://www.youtube.com/watch?v=4S5m5Jhneds

--- a/ssr-rsc-intro/README.md
+++ b/ssr-rsc-intro/README.md
@@ -151,9 +151,17 @@ The problem is that once we hydrate our application, it creates a new `fetchData
 
 `except via a Suspense-compatible library or framework.`
 
-Unfortunately this is a touchy subject, and React has been criticized for potentially keeping this implementation "secret" to discourage us from integrating with Suspense on our own. Instead, we should rely on a meta-framework like NextJS or Remix. This has been a controversy / drama. In this tutorial, I will fix this error with a very straightforward logic: using an if-statement, if I am on the clientside, then return a Promise that never resolves; Eventually the streaming HTML will come in. This is absolutely not a production-ready solution, but I wanted to be transparent about this whole caveat.
+Unfortunately this is a touchy subject, and React has been criticized for potentially keeping this implementation "secret" to discourage us from integrating with Suspense on our own. Instead, telling us to [rely on a meta-framework](https://react.dev/blog/2022/03/29/react-v18#suspense-in-data-frameworks) like NextJS or Remix. This has been a controversy. What's worse is that a lot of these meta-frameworks implement solutions using "React internals" that technically are not "recommended".
 
-You can 
+In this example, I am using the `use` hook which is the official way to make a component suspend. However, you can see the infinite loop problem we have.
+
+Check out my solution in `streaming-with-hydration/StreamingWithHydration.jsx` file. I replaced the `fetchData` method with a new one that throws promises instead of returning a promise.
+
+Now you can visit http://localhost:3000/im-streaming-html-with-hydration to see everything working.
+
+The sad truth is that "throwing promises" is not an officially recommended way to suspend a component. And React team warns us that this implementation may change in the future. Meanwhile, meta-frameworks have gone ahead with various implementations to solve this and make `Suspense` + `Streaming` ready for its users.
+
+It is a weird situation where the core library itself doesn't fully support the functionality, but frameworks built around it have gone on and touted as ready for production.
 
 # SECTION 6: React Server Components
 

--- a/ssr-rsc-intro/im-streaming-html/client2.js
+++ b/ssr-rsc-intro/im-streaming-html/client2.js
@@ -1,0 +1,5 @@
+const React = require("react");
+const ReactDOM = require("react-dom/client");
+const App = require("./Streaming.jsx");
+
+ReactDOM.hydrateRoot(document, <App />);

--- a/ssr-rsc-intro/index.js
+++ b/ssr-rsc-intro/index.js
@@ -84,7 +84,7 @@ app.get("/my-first-react-counter", (req, res) => {
 });
 
 /**
- * SECTION 4: Serverside Rendering React with Suspense, Streaming and Clientside Hydration
+ * SECTION 4: Serverside Rendering React with Suspense, Streaming, but WITHOUT Clientside Hydration
  */
 
 const { renderToPipeableStream } = require("react-dom/server");
@@ -111,6 +111,20 @@ const StreamingApp = require("./im-streaming-html/Streaming.jsx");
 app.get("/im-streaming-html", (req, res) => {
   const { pipe } = renderToPipeableStream(StreamingApp(), {
     bootstrapScripts: [],
+    onShellReady() {
+      res.setHeader("content-type", "text/html");
+      pipe(res);
+    },
+  });
+});
+
+/**
+ * SECTION 5: Serverside Rendering React with Suspense, Streaming, WITH Clientside Hydration
+ */
+
+app.get("/im-streaming-html-with-hydration", (req, res) => {
+  const { pipe } = renderToPipeableStream(StreamingApp(), {
+    bootstrapScripts: ["suspenseHydrated.bundle.js"],
     onShellReady() {
       res.setHeader("content-type", "text/html");
       pipe(res);

--- a/ssr-rsc-intro/index.js
+++ b/ssr-rsc-intro/index.js
@@ -132,6 +132,18 @@ app.get("/im-streaming-html-with-hydration-broken", (req, res) => {
   });
 });
 
+const StreamingAppHydration = require("./streaming-with-hydration/StreamingWithHydration.jsx");
+
+app.get("/im-streaming-html-with-hydration", (req, res) => {
+  const { pipe } = renderToPipeableStream(StreamingAppHydration(), {
+    bootstrapScripts: ["suspenseHydratedWorking.bundle.js"],
+    onShellReady() {
+      res.setHeader("content-type", "text/html");
+      pipe(res);
+    },
+  });
+});
+
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });

--- a/ssr-rsc-intro/index.js
+++ b/ssr-rsc-intro/index.js
@@ -122,7 +122,7 @@ app.get("/im-streaming-html", (req, res) => {
  * SECTION 5: Serverside Rendering React with Suspense, Streaming, WITH Clientside Hydration
  */
 
-app.get("/im-streaming-html-with-hydration", (req, res) => {
+app.get("/im-streaming-html-with-hydration-broken", (req, res) => {
   const { pipe } = renderToPipeableStream(StreamingApp(), {
     bootstrapScripts: ["suspenseHydrated.bundle.js"],
     onShellReady() {

--- a/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
+++ b/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
@@ -1,0 +1,79 @@
+const React = require("react");
+
+module.exports = function () {
+  const comments = [];
+
+  for (let i = 0; i < 10; i++) {
+    comments.push(
+      <React.Suspense fallback={<div>Loading comment...</div>} key={i}>
+        <Comment commentId={i} />
+      </React.Suspense>
+    );
+  }
+
+  return (
+    <html lang="en-us">
+      <head>
+        <title>Hello World</title>
+      </head>
+      <body>
+        <div style={{ margin: "20px" }}>
+          <h1>Here is a Big Comment Section</h1>
+          {comments}
+        </div>
+      </body>
+    </html>
+  );
+};
+
+const fetchData = function (commentId) {
+  console.log(`fetching comment ${commentId}`);
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(`Fetched data for comment # ${commentId}`);
+    }, 1000 * commentId);
+  });
+};
+
+const Comment = function ({ commentId }) {
+  const promise = fetchData(commentId);
+  const data = React.use(promise); // What is `use()`? See comment below...
+  return data ? <div>{data}</div> : null;
+};
+
+/**
+From the [React docs](https://react.dev/reference/react/Suspense):
+
+> Only Suspense-enabled data sources will activate the Suspense component. They include:
+>
+> - Data fetching with Suspense-enabled frameworks like Relay and Next.js
+> - Lazy-loading component code with lazy
+> - Reading the value of a cached Promise with use
+> Suspense does not detect when data is fetched inside an Effect or event handler.
+>
+
+That means if you do this:
+
+```jsx
+const Component = () => {
+  const [data, setData] = useState();
+  useEffect(() => {
+    fetchMyData().then((result) => setData(result))
+  }, []);
+
+  return <div>{data}</div>
+}
+```
+
+Then wrapping it with Suspense DOES NOTHING!
+
+```jsx
+<Suspense fallback={<div>Loading...</div>}>
+  <Component>
+</Suspense>
+```
+
+You must use `lazy` or `use`.
+
+If you have meta-framework like Next.js, they might have a special API you can use as well.
+ */

--- a/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
+++ b/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
@@ -27,6 +27,8 @@ module.exports = function () {
 };
 
 const fetchData = function (commentId) {
+  if (typeof window !== "undefined") return new Promise(() => {});
+
   console.log(`fetching comment ${commentId}`);
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -36,44 +38,14 @@ const fetchData = function (commentId) {
 };
 
 const Comment = function ({ commentId }) {
+  const [isOpen, setIsOpen] = React.useState(false);
   const promise = fetchData(commentId);
-  const data = React.use(promise); // What is `use()`? See comment below...
-  return data ? <div>{data}</div> : null;
+  const data = React.use(promise);
+  return data ? (
+    <div>
+      {data}
+      <button onClick={() => setIsOpen(!isOpen)}>Open Comment</button>
+      {isOpen && <div>You opened the rest of the comment for {commentId}</div>}
+    </div>
+  ) : null;
 };
-
-/**
-From the [React docs](https://react.dev/reference/react/Suspense):
-
-> Only Suspense-enabled data sources will activate the Suspense component. They include:
->
-> - Data fetching with Suspense-enabled frameworks like Relay and Next.js
-> - Lazy-loading component code with lazy
-> - Reading the value of a cached Promise with use
-> Suspense does not detect when data is fetched inside an Effect or event handler.
->
-
-That means if you do this:
-
-```jsx
-const Component = () => {
-  const [data, setData] = useState();
-  useEffect(() => {
-    fetchMyData().then((result) => setData(result))
-  }, []);
-
-  return <div>{data}</div>
-}
-```
-
-Then wrapping it with Suspense DOES NOTHING!
-
-```jsx
-<Suspense fallback={<div>Loading...</div>}>
-  <Component>
-</Suspense>
-```
-
-You must use `lazy` or `use`.
-
-If you have meta-framework like Next.js, they might have a special API you can use as well.
- */

--- a/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
+++ b/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
@@ -2,13 +2,11 @@ const React = require("react");
 
 module.exports = function () {
   const comments = [];
-  const resource = [];
 
   for (let i = 0; i < 10; i++) {
-    resource.push(fetchData(i));
     comments.push(
       <React.Suspense fallback={<div>Loading comment...</div>} key={i}>
-        <Comment resource={resource[i]} />
+        <Comment resource={fetchData(i)} />
       </React.Suspense>
     );
   }

--- a/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
+++ b/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
@@ -43,9 +43,8 @@ const Comment = function ({ commentId }) {
   const data = React.use(promise);
   return data ? (
     <div>
-      {data}
       <button onClick={() => setIsOpen(!isOpen)}>Open Comment</button>
-      {isOpen && <div>You opened the rest of the comment for {commentId}</div>}
+      {isOpen && <div>{data}</div>}
     </div>
   ) : null;
 };

--- a/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
+++ b/ssr-rsc-intro/streaming-with-hydration/StreamingWithHydration.jsx
@@ -43,7 +43,13 @@ const Comment = function ({ commentId }) {
   const data = React.use(promise);
   return data ? (
     <div>
-      <button onClick={() => setIsOpen(!isOpen)}>Open Comment</button>
+      <button
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        Open Comment
+      </button>
       {isOpen && <div>{data}</div>}
     </div>
   ) : null;

--- a/ssr-rsc-intro/streaming-with-hydration/client.js
+++ b/ssr-rsc-intro/streaming-with-hydration/client.js
@@ -1,0 +1,5 @@
+const React = require("react");
+const ReactDOM = require("react-dom/client");
+const App = require("./StreamingWithHydration.jsx");
+
+ReactDOM.hydrateRoot(document, <App />);

--- a/ssr-rsc-intro/webpack.config.js
+++ b/ssr-rsc-intro/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: {
     app: path.resolve(__dirname, "./my-first-react-app/client.js"),
     suspense: path.resolve(__dirname, "./im-streaming-html/client.js"),
+    suspenseHydrated: path.resolve(__dirname, "./im-streaming-html/client2.js"),
   },
   output: {
     path: path.resolve(__dirname, "./public"),

--- a/ssr-rsc-intro/webpack.config.js
+++ b/ssr-rsc-intro/webpack.config.js
@@ -5,6 +5,10 @@ module.exports = {
     app: path.resolve(__dirname, "./my-first-react-app/client.js"),
     suspense: path.resolve(__dirname, "./im-streaming-html/client.js"),
     suspenseHydrated: path.resolve(__dirname, "./im-streaming-html/client2.js"),
+    suspenseHydratedWorking: path.resolve(
+      __dirname,
+      "./streaming-with-hydration/client.js"
+    ),
   },
   output: {
     path: path.resolve(__dirname, "./public"),


### PR DESCRIPTION
In Section 5, I update my Suspense demo to `throw` promises. And then explain a little bit about the differences in "supported" APIs and "internal" APIs. 